### PR TITLE
Fix card tooltip on mobile

### DIFF
--- a/play.css
+++ b/play.css
@@ -870,3 +870,12 @@ body.shift #tooltip.focus { display: block; }
 
 .card_back{background-image:url(cards.1x/card_back_116.webp)}
 @media (min-resolution: 97dpi) { .card_back{background-image:url(cards.2x/card_back_116.webp)} }
+
+/* Reposition card tooltips for mobile */
+@media only screen and (max-width: 610px) {
+  #tooltip.card {
+    right: auto;
+    left: 5px;
+    top: 75px;
+  }
+}


### PR DESCRIPTION
This fixes card tooltips hiding behind screen on mobile.

**Before:**                                         
<img width="200" alt="Screenshot 2022-06-14 at 15 40 29" src="https://user-images.githubusercontent.com/576786/173765317-b6bd587a-47ee-45eb-9966-9ce5097bef38.png"> 

**After:**
<img width="200" alt="Screenshot 2022-06-14 at 15 40 19" src="https://user-images.githubusercontent.com/576786/173765314-8c3738d7-7df8-4f0f-89fe-84954494bec3.png">
